### PR TITLE
Add service to quickly revert system into golden image state

### DIFF
--- a/overlay/usr/lib/systemd/system/emergency-revert.service
+++ b/overlay/usr/lib/systemd/system/emergency-revert.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Emergency revert to golden image state
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl stop user.slice
+ExecStartPost=/bin/systemctl stop root.mount
+ExecStartPost=/bin/systemctl stop systemd-journald
+ExecStartPost=/bin/systemctl stop var-log-journal.mount
+ExecStartPost=/bin/systemctl stop mnt.mount
+ExecStartPost=/bin/systemctl start fs-initialize
+ExecStartPost=/bin/systemctl reboot


### PR DESCRIPTION
This adds a new OS service called "emergency-revert" which reformats the RW overlay filesystem, effectively reverting the payload into a "golden image" state, as if payload was just reprogrammed. This could help "quickly" recover the payload without actually running the reprogramming sequence, which takes a while.

The service executes these steps:

- Stop user systemd session (i.e. all CLICK python services)
- Unmount overlay, journal, and ext4 filesystems
- Run [fs-initialize.service](https://github.com/MIT-STARLab/CLICK-Image-Tool/blob/A/overlay/usr/lib/systemd/system/fs-initialize.service), which reformats ext4 filesystem and sets up initial directories
- Reboot payload

Successfully tested on EM using COSMOS PL_EXEC command with "systemctl start emergency-revert".